### PR TITLE
Download improvements

### DIFF
--- a/_data/releases.yml
+++ b/_data/releases.yml
@@ -2,18 +2,16 @@
   description: Development
   channel: development
   released: June 6, 2025
-  has_anaconda: true
+  url_anaconda: https://anaconda.org/conda-forge/wxwidgets
 - version: 3.2.8
   description: Latest Stable
   channel: stable
   released: April 24th, 2025
   stable_api_since: July 7, 2022
-  bin_url_debian: https://docs.codelite.org/wxWidgets/repo32/#ubuntu-and-debian
-  bin_url_fedora: https://docs.codelite.org/wxWidgets/repo32/#fedora-and-opensuse
+  url_codelite: https://docs.codelite.org/wxWidgets/repo32/
 - version: 3.0.5
   description: Old Stable
   channel: old_stable
   released: April 27th, 2020
   stable_api_since: November 11th, 2013
-  bin_url_debian: https://wiki.codelite.org/pmwiki.php/Main/WxWidgets30Binaries#toc2
-  bin_url_fedora: https://wiki.codelite.org/pmwiki.php/Main/WxWidgets30Binaries#toc3
+  url_codelite: https://wiki.codelite.org/pmwiki.php/Main/WxWidgets30Binaries

--- a/downloads/index.md
+++ b/downloads/index.md
@@ -220,17 +220,23 @@ are available below.
                   </p>
 
             {% for architecture in page.architectures %}
-              <h6 class="card-subtitle text-muted">{{ architecture.description }}</h6>
-              <p class="card-text ml-2">
+              {% assign show_architecture_description = true %}
               {% for bin in page.binaries %}
                 {% assign asset_filename = "wxMSW-" | append: release_version_bin | append: "_" | append: compiler.id | append: architecture.postfix | append: "_" | append: bin.id | append: ".7z" %}
                 {% assign asset = release_assets | where: "name", asset_filename | first %}
                 {% if asset %}
-                <a href="{{ asset.browser_download_url }}" class="wxdl_{{ asset.id }}">{{ bin.description }}</a> 
-                <br />
+                  {% if show_architecture_description %}
+                    <h6 class="card-subtitle text-muted">{{ architecture.description }}</h6>
+                    <p class="card-text ml-2">
+                    {% assign show_architecture_description = false %}
+                  {% endif %}
+                  <a href="{{ asset.browser_download_url }}" class="wxdl_{{ asset.id }}">{{ bin.description }}</a> 
+                  <br />
                 {% endif %}
               {% endfor %}
-              </p>
+              {% unless show_architecture_description %}
+                </p>
+              {% endunless %}
             {% endfor %}
 
                 </div>

--- a/downloads/index.md
+++ b/downloads/index.md
@@ -146,18 +146,14 @@ are available below.
 
         <br />
 
-        {% if release.bin_url_debian and release.bin_url_fedora %}
+        {% if release.url_codelite %}
         Thanks to <a href="https://codelite.org/">CodeLite</a> team, binaries for common Linux distributions
-        are also available, please see <a href="https://docs.codelite.org/wxWidgets/repo320/">the instructions</a>
-        for using their repository, which contains packages for:
-        <ul>
-          <li><a href="{{ release.bin_url_debian }}" target="_new">Debian / Ubuntu</a></li>
-          <li><a href="{{ release.bin_url_fedora }}" target="_new">Fedora / openSUSE</a></li>
-        </ul>
+        are also available, please see <a href="{{ release.url_codelite }}">the instructions</a>
+        for using their repository.
         {% endif %}
 
-        {% if release.has_anaconda %}
-        wxWidgets is also on <a href="https://anaconda.org/conda-forge/wxwidgets"> <img src="https://anaconda.org/conda-forge/wxwidgets/badges/version.svg" /> </a>
+        {% if release.url_anaconda %}
+        wxWidgets is also on <a href="{{ release.url_anaconda }}"> <img src="{{ release.url_anaconda }}/badges/version.svg" /> </a>
         {% endif %}
       </div>
       <div class="card-footer text-muted">


### PR DESCRIPTION
These are the changes I had in mind. Simplify the codelite section to use only 1 link.
And define the anaconda URL in releases.yml.

And only show the architecture description when it has assets.