### PR TITLE
Rearrange documentation links

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -11,10 +11,10 @@ the manual is also available, built nightly.
 
 <div class="row my-3 justify-content-md-center">
   <div class="col-md-6">
-    <p><a href="https://docs.wxwidgets.org/3.2/" class="btn btn-outline-primary btn-lg btn-block" role="button">3.2 Online Manual</a></p>
-    <p><a href="https://docs.wxwidgets.org/3.0/" class="btn btn-outline-primary btn-lg btn-block" role="button">3.0 Online Manual</a></p>
-    <p><a href="https://docs.wxwidgets.org/2.8/" class="btn btn-outline-primary btn-lg btn-block" role="button">2.8 Online Manual</a></p>
-    <p><a href="https://docs.wxwidgets.org/latest/" class="btn btn-outline-primary btn-lg btn-block" role="button">Development Manual</a></p>
+    <p><a href="https://docs.wxwidgets.org/latest/" class="btn btn-outline-info btn-lg btn-block" role="button">3.3 (Development) Manual</a></p>
+    <p><a href="https://docs.wxwidgets.org/3.2/" class="btn btn-outline-primary btn-lg btn-block" role="button">3.2 (Stable) Manual</a></p>
+    <p><a href="https://docs.wxwidgets.org/3.0/" class="btn btn-outline-secondary btn-lg btn-block" role="button">3.0 (Old Stable) Manual</a></p>
+    <p><a href="https://docs.wxwidgets.org/2.8/" class="btn btn-outline-secondary btn-lg btn-block" role="button">2.8 (Ancient Stable) Manual</a></p>
   </div>
 </div>
 


### PR DESCRIPTION
Put "Development" link first and call it "3.3" and also add descriptions for the other versions.

Change buttons borders to better distinguish them.

Closes #109.